### PR TITLE
v1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "any_of"
-version = "1.1.0"
+version = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "any_of"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 description = "A general optional sum of product type which can be Neither, Left, Right or Both."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -22,16 +22,25 @@ These abstractions allow to express dynamic states, optional values, and branchi
         - `Either::Left`: Only the left value is present.
         - `Either::Right`: Only the right value is present.
         - `Both`: Both values are present.
-    - ```
-      # Conceptually, it combines variants in the following way
+    - Conceptually, it combines variants in the following way:
+      ```
       AnyOf<L, R> = Neither | Either<L, R> | Both<L, R>
-      
-      # Its cases are:
-      AnyOf<L, R> = Neither | Either::Left(L) | Either::Right(R) | Both(L, R)
-      
-      # It can also be viewed as a product of two optional types:
+      ```
+    - Its cases are:
+      ```
+      AnyOf(L, R) = Neither | Either::Left(L) | Either::Right(R) | Both(L, R)
+      ```
+    - It can also be viewed as a product of two optional types:
+      ```
       AnyOf<L, R>::any = (Option<L>, Option<R>)
       ```
+      - with:
+        ```
+        Neither::any = (None, None)
+        Either::Left(L)::any = (Some(L), None)
+        Either::Right(R)::any = (None, Some(R))
+        Both::any = (Some(L), Some(R))
+        ```
 
 2. **`Either<L, R>`**
     - A simple sum type representing one of two values.
@@ -54,6 +63,7 @@ These abstractions allow to express dynamic states, optional values, and branchi
 4. **Enhanced Type Composition**
     - Complex types like `AnyOf4`, `AnyOf8`, and `AnyOf16` are implemented for handling larger, 
     structured combinations via nested `AnyOf` structures.
+    - The types implement the `LeftOrRight<L, R>` trait. 
 
 ### Features and Utilities
 
@@ -64,10 +74,10 @@ These abstractions allow to express dynamic states, optional values, and branchi
     - Unwrapping: `unwrap_left`, `unwrap_right`, `unwrap_both`.
 
 - Flexible combinations:
-    - Operators like:
-      - `&` to combine, or,
-      - `|` to filter, or,
-      - `!` to swap values in `AnyOf`.
+    - Operators :
+      - `&` to combine `AnyOf` values, or,
+      - `|` to filter `AnyOf` values, or,
+      - `!` to swap  `AnyOf`, `Either` and `Both` values.
     - Default value handling and state manipulation methods.
 
 ### Use Cases

--- a/src/any_of_x.rs
+++ b/src/any_of_x.rs
@@ -36,6 +36,7 @@
 //! Use `AnyOf16` or higher with caution.
 
 use crate::AnyOf;
+use crate::LeftOrRight;
 
 /// A type representing a combination of four possible types.
 pub type AnyOf4<LL, LR = LL, RL = LR, RR = RL> = AnyOf<AnyOf<LL, LR>, AnyOf<RL, RR>>;

--- a/src/both.rs
+++ b/src/both.rs
@@ -47,9 +47,9 @@
 //! }
 //! ```
 
-use core::ops::Not;
 use crate::either::Either;
-use crate::Couple;
+use crate::{Couple, LeftOrRight};
+use core::ops::Not;
 
 /// `Both` is a generic struct that allows pairing two values of potentially different types.
 ///
@@ -177,7 +177,7 @@ impl<L, R> Both<L, R> {
     pub fn into_right(self) -> Either<L, R> {
         Either::<L, R>::Right(self.right)
     }
-    
+
     /// Applies the provided transformation functions to the `left` and `right` values of this `Both` instance.
     ///
     /// # Type Parameters
@@ -213,7 +213,6 @@ impl<L, R> Both<L, R> {
             right: fr(self.right),
         }
     }
-    
 
     /// Swaps the `left` and `right` values of this `Both` instance.
     ///
@@ -235,6 +234,46 @@ impl<L, R> Both<L, R> {
             left: self.right,
             right: self.left,
         }
+    }
+}
+
+impl<L, R> LeftOrRight<L, R> for Both<L, R> {
+    /// Always true
+    fn is_left(&self) -> bool {
+        true
+    }
+
+    /// Always true
+    fn is_right(&self) -> bool {
+        true
+    }
+
+    /// Returns references to the `Left` and `Right` values as a tuple of `Option`.
+    ///
+    /// ## Returns
+    ///
+    /// A tuple containing an `Option` reference to the left value and an `Option`
+    /// reference to the right value. The options will always contain two values.
+    fn any(&self) -> (Option<&L>, Option<&R>) {
+        (self.left(), self.right())
+    }
+
+    /// Returns a reference to the left value.
+    ///
+    /// ## Returns
+    ///
+    /// An `Option` containing a reference to the left value.
+    fn left(&self) -> Option<&L> {
+        Some(&self.left)
+    }
+
+    /// Returns a reference to the right value.
+    ///
+    /// ## Returns
+    ///
+    /// An `Option` containing a reference to the right value.
+    fn right(&self) -> Option<&R> {
+        Some(&self.right)
     }
 }
 

--- a/src/concepts.rs
+++ b/src/concepts.rs
@@ -1,0 +1,67 @@
+//! This module defines utility types and traits for working with dual-variant data structures,
+//! such as "product types" (tuples) and "sum types" (LeftOrRight) that can hold one of two possible variants.
+//!
+//! It includes definitions for `Couple`, `Pair`, and the `LeftOrRight` trait,
+//! providing type-safe methods for ergonomic and efficient access to such data.
+
+/// The `(T, U)` tuple.
+pub type Couple<T, U> = (T, U);
+
+/// A shortcut for `Couple<T, T>`.
+pub type Pair<T> = Couple<T, T>;
+
+/// The `LeftOrRight` trait provides utility methods for working with types that 
+/// can represent one of two possible variants: a "left" variant (`L`) or a 
+/// "right" variant (`R`) (or possibly both).
+///
+/// ## Provided Methods
+///
+/// - **`is_left`**: Checks if the value is the `L` (left) variant.
+/// - **`is_right`**: Checks if the value is the `R` (right) variant.
+/// - **`any`**: Returns both left and right values wrapped in `Option`s as a tuple.
+/// - **`left`**: Returns a reference to the left variant if present.
+/// - **`right`**: Returns a reference to the right variant if present.
+///
+/// This trait is useful for types implementing a "sum type"-like behavior, where
+/// values may contain one of two possible forms, and you need utilities for
+/// type-safe and ergonomic access to their internals.
+pub trait LeftOrRight<L, R> {
+    /// Checks if the `LeftOrRight<L, R>` value is the `L` variant.
+    ///
+    /// ## Returns
+    ///
+    /// `true` if the value is `L`, otherwise `false`.
+    fn is_left(&self) -> bool;
+
+    /// Checks if the `LeftOrRight<L, R>` value is the `R` variant.
+    ///
+    /// ## Returns
+    ///
+    /// `true` if the value is `R`, otherwise `false`.
+    fn is_right(&self) -> bool;
+
+    /// Returns references to the `L` or `R` values as a tuple of `Option`.
+    ///
+    /// ## Returns
+    ///
+    /// A tuple containing an `Option` reference to the left value and an `Option`
+    /// reference to the right value.
+    fn any(&self) -> Couple<Option<&L>, Option<&R>>;
+
+    /// Returns a reference to the left value if it exists.
+    ///
+    /// ## Returns
+    ///
+    /// An `Option` containing a reference to the left value if the variant is `L`,
+    /// otherwise `None`.
+    fn left(&self) -> Option<&L>;
+
+    /// Returns a reference to the right value if it exists.
+    ///
+    /// ## Returns
+    ///
+    /// An `Option` containing a reference to the right value if the variant is `R`,
+    /// otherwise `None`.
+    fn right(&self) -> Option<&R>;
+    
+}

--- a/src/either.rs
+++ b/src/either.rs
@@ -1,7 +1,7 @@
-//! This module provides the `Either` enum, a utility type that represents a value 
+//! This module provides the `Either` enum, a utility type that represents a value
 //! that can be one of two variants: `Left` or `Right`.
 //!
-//! This is useful for scenarios where a value can have one of two possible types, often used as a lightweight 
+//! This is useful for scenarios where a value can have one of two possible types, often used as a lightweight
 //! alternative to `Result` or for decision trees in functional programming.
 //!
 //! The `Either` enum has the following scenarios of use:
@@ -9,7 +9,7 @@
 //! - `Right`: A variant for holding a value of type `R`.
 //!
 //! # Public API
-//! This module provides numerous utility methods for creating, inspecting, and 
+//! This module provides numerous utility methods for creating, inspecting, and
 //! transforming instances of `Either`.
 //!
 //! ## Creation
@@ -21,28 +21,28 @@
 //! - [`Either::is_right`]: Returns `true` if the value is `Right`.
 //! - [`Either::left`]: Returns a reference to the left value if it exists.
 //! - [`Either::right`]: Returns a reference to the right value if it exists.
-//! - [`Either::any`]: Returns a tuple of `Option` references to either the left 
+//! - [`Either::any`]: Returns a tuple of `Option` references to either the left
 //!   or the right value, depending on the variant.
 //!
 //! ## Default Values
 //! - [`Either::left_or`]: Returns the left value or a provided default.
 //! - [`Either::right_or`]: Returns the right value or a provided default.
-//! - [`Either::left_or_else`]: Returns the left value or computes a default using 
+//! - [`Either::left_or_else`]: Returns the left value or computes a default using
 //!   a closure.
-//! - [`Either::right_or_else`]: Returns the right value or computes a default 
+//! - [`Either::right_or_else`]: Returns the right value or computes a default
 //!   using a closure.
 //!
 //! ## Unwrapping
-//! - [`Either::unwrap_left`]: Extracts the left value, panicking if the value is 
+//! - [`Either::unwrap_left`]: Extracts the left value, panicking if the value is
 //!   a `Right`.
-//! - [`Either::unwrap_right`]: Extracts the right value, panicking if the value is 
+//! - [`Either::unwrap_right`]: Extracts the right value, panicking if the value is
 //!   a `Left`.
 //!
 //! ## Transformation
 //! - [`Either::swap`]: Swaps the `Left` variant for `Right` and vice versa.
 //! - [`Either::map_left`]: Applies a function to transform the `Left` value.
 //! - [`Either::map_right`]: Applies a function to transform the `Right` value.
-//! - [`Either::map`]: Applies separate functions to transform either the `Left` 
+//! - [`Either::map`]: Applies separate functions to transform either the `Left`
 //!   or `Right` value depending on the variant.
 //!
 //! ## Examples
@@ -50,6 +50,7 @@
 //!
 //! ```rust
 //! use any_of::Either;
+//! use any_of::concepts::LeftOrRight;
 //!
 //! let left_value: Either<i32, &str> = Either::new_left(10);
 //! assert!(left_value.is_left());
@@ -66,11 +67,12 @@
 //!
 
 use core::ops::Not;
+use crate::LeftOrRight;
 
 /// The `Either` enum is a utility type that can hold a value of one of two variants: `Left(L)` or `Right(R)`.
 ///
-/// It serves as a straightforward alternative to `Result`, providing a way to perform operations 
-/// on values of two possible types. Unlike `Result`, it does not imply any specific meaning 
+/// It serves as a straightforward alternative to `Result`, providing a way to perform operations
+/// on values of two possible types. Unlike `Result`, it does not imply any specific meaning
 /// to the variants.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub enum Either<L, R> {
@@ -103,64 +105,6 @@ impl<L, R> Either<L, R> {
     /// A new instance of `Either` with the value in the `Right` variant.
     pub fn new_right(right: R) -> Self {
         Self::Right(right)
-    }
-
-    /// Checks if the `Either` value is the `Left` variant.
-    ///
-    /// ## Returns
-    ///
-    /// `true` if the value is `Left`, otherwise `false`.
-    pub fn is_left(&self) -> bool {
-        matches!(self, Self::Left(_))
-    }
-
-    /// Checks if the `Either` value is the `Right` variant.
-    ///
-    /// ## Returns
-    ///
-    /// `true` if the value is `Right`, otherwise `false`.
-    pub fn is_right(&self) -> bool {
-        matches!(self, Self::Right(_))
-    }
-
-    /// Returns references to the `Left` and `Right` values as a tuple of `Option`.
-    ///
-    /// ## Returns
-    ///
-    /// A tuple containing an `Option` reference to the left value and an `Option`
-    /// reference to the right value. Only one of the options will contain a value
-    /// depending on the variant.
-    pub fn any(&self) -> (Option<&L>, Option<&R>) {
-        match self {
-            Self::Left(l) => (Some(l), None),
-            Self::Right(r) => (None, Some(r)),
-        }
-    }
-
-    /// Returns a reference to the left value if it exists.
-    ///
-    /// ## Returns
-    ///
-    /// An `Option` containing a reference to the left value if the variant is `Left`,
-    /// otherwise `None`.
-    pub fn left(&self) -> Option<&L> {
-        match self {
-            Self::Left(l) => Some(l),
-            Self::Right(_) => None,
-        }
-    }
-
-    /// Returns a reference to the right value if it exists.
-    ///
-    /// ## Returns
-    ///
-    /// An `Option` containing a reference to the right value if the variant is `Right`,
-    /// otherwise `None`.
-    pub fn right(&self) -> Option<&R> {
-        match self {
-            Self::Left(_) => None,
-            Self::Right(r) => Some(r),
-        }
     }
 
     /// Returns the left value or computes a default using the provided closure.
@@ -312,6 +256,41 @@ impl<L, R> Either<L, R> {
             Self::Right(r) => Either::<L2, R2>::Right(fr(r)),
         }
     }
+}
+
+impl<L, R> LeftOrRight<L, R> for Either<L, R> {
+
+    /// See [crate::LeftOrRight::is_left].
+    fn is_left(&self) -> bool {
+        matches!(self, Self::Left(_))
+    }
+
+    /// See [crate::LeftOrRight::is_right].
+    fn is_right(&self) -> bool {
+        matches!(self, Self::Right(_))
+    }
+
+    /// See [crate::LeftOrRight::any].
+    fn any(&self) -> (Option<&L>, Option<&R>) {
+        (self.left(), self.right())
+    }
+
+    /// See [crate::LeftOrRight::left].
+    fn left(&self) -> Option<&L> {
+        match self {
+            Self::Left(l) => Some(l),
+            Self::Right(_) => None,
+        }
+    }
+
+    /// See [crate::LeftOrRight::right].
+    fn right(&self) -> Option<&R> {
+        match self {
+            Self::Left(_) => None,
+            Self::Right(r) => Some(r),
+        }
+    }
+
 }
 
 impl<L, R> Not for Either<L, R> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,5 @@
 use crate::AnyOf;
+use crate::LeftOrRight;
 
 mod utils {
     use core::ops::Add;


### PR DESCRIPTION
- Added `LeftOrRight` trait definition in `src/concepts.rs`.
- Implemented `LeftOrRight` for `Either`, `Both`, and `AnyOf`.
- Removed redundant methods from `Either` and `AnyOf`.
- Adjusted imports and updated references in documentation and examples.
- Updated README.md to reflect the new `LeftOrRight` trait feature.