### PR TITLE
Merge to master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "any_of"
-version = "1.2.0"
+version = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "any_of"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 description = "A general optional sum of product type which can be Neither, Left, Right or Both."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ manner.
         - Provides the methods `is_right()`, `is_left()`, `any()`, `left()` and `right()`.
         - Implemented by `AnyOf`, `Either` and `Both`,
         - Can be implemented by a custom type.
+    - Other useful traits : `Unwrap<L, R>`, `Swap<L, R>` and `Map<L, R>`.
 
 ### Features and Utilities
 

--- a/src/both.rs
+++ b/src/both.rs
@@ -47,8 +47,9 @@
 //! }
 //! ```
 
+use crate::concepts::Swap;
 use crate::either::Either;
-use crate::{Couple, LeftOrRight};
+use crate::{Couple, LeftOrRight, Map, Unwrap};
 use core::ops::Not;
 
 /// `Both` is a generic struct that allows pairing two values of potentially different types.
@@ -177,64 +178,6 @@ impl<L, R> Both<L, R> {
     pub fn into_right(self) -> Either<L, R> {
         Either::<L, R>::Right(self.right)
     }
-
-    /// Applies the provided transformation functions to the `left` and `right` values of this `Both` instance.
-    ///
-    /// # Type Parameters
-    /// - `L2`: The resulting type of the transformed `left` value.
-    /// - `R2`: The resulting type of the transformed `right` value.
-    /// - `FL`: The type of the function used to transform the `left` value.
-    /// - `FR`: The type of the function used to transform the `right` value.
-    ///
-    /// # Arguments
-    /// - `fl`: A function that takes the `left` value and transforms it into a value of type `L2`.
-    /// - `fr`: A function that takes the `right` value and transforms it into a value of type `R2`.
-    ///
-    /// # Returns
-    /// A new `Both` instance with transformed `left` and `right` values.
-    ///
-    /// # Examples
-    /// ```rust
-    /// use any_of::Both;
-    ///
-    /// let both = Both::new(2, "example");
-    /// let transformed = both.map(|left| left * 2, |right| format!("{}!", right));
-    ///
-    /// assert_eq!(transformed.left, 4);
-    /// assert_eq!(transformed.right, "example!");
-    /// ```
-    pub fn map<L2, R2, FL, FR>(self, fl: FL, fr: FR) -> Both<L2, R2>
-    where
-        FL: FnOnce(L) -> L2,
-        FR: FnOnce(R) -> R2,
-    {
-        Both {
-            left: fl(self.left),
-            right: fr(self.right),
-        }
-    }
-
-    /// Swaps the `left` and `right` values of this `Both` instance.
-    ///
-    /// # Returns
-    /// A new `Both` instance where the `left` and `right` values are swapped.
-    ///
-    /// # Examples
-    /// ```rust
-    /// use any_of::Both;
-    ///
-    /// let both = Both::new(42, "example");
-    /// let swapped = both.swap();
-    ///
-    /// assert_eq!(swapped.left, "example");
-    /// assert_eq!(swapped.right, 42);
-    /// ```
-    pub fn swap(self) -> Both<R, L> {
-        Both {
-            left: self.right,
-            right: self.left,
-        }
-    }
 }
 
 impl<L, R> LeftOrRight<L, R> for Both<L, R> {
@@ -274,6 +217,84 @@ impl<L, R> LeftOrRight<L, R> for Both<L, R> {
     /// An `Option` containing a reference to the right value.
     fn right(&self) -> Option<&R> {
         Some(&self.right)
+    }
+}
+
+impl<L, R> Swap<L, R> for Both<L, R> {
+    type Output = Both<R, L>;
+
+
+    /// Swaps the `left` and `right` values of this `Both` instance.
+    ///
+    /// # Returns
+    /// A new `Both` instance where the `left` and `right` values are swapped.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use any_of::Both;
+    /// use any_of::Swap;
+    ///
+    /// let both = Both::new(42, "example");
+    /// let swapped = both.swap();
+    ///
+    /// assert_eq!(swapped.left, "example");
+    /// assert_eq!(swapped.right, 42);
+    /// ```
+    fn swap(self) -> Self::Output {
+        Both {
+            left: self.right,
+            right: self.left,
+        }
+    }
+}
+
+impl<L, R> Map<L, R> for Both<L, R> {
+    type Output<L2, R2> = Both<L2, R2>;
+
+    /// Applies the provided transformation functions to the `left` and `right` values of this `Both` instance.
+    ///
+    /// # Type Parameters
+    /// - `L2`: The resulting type of the transformed `left` value.
+    /// - `R2`: The resulting type of the transformed `right` value.
+    /// - `FL`: The type of the function used to transform the `left` value.
+    /// - `FR`: The type of the function used to transform the `right` value.
+    ///
+    /// # Arguments
+    /// - `fl`: A function that takes the `left` value and transforms it into a value of type `L2`.
+    /// - `fr`: A function that takes the `right` value and transforms it into a value of type `R2`.
+    ///
+    /// # Returns
+    /// A new `Both` instance with transformed `left` and `right` values.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use any_of::{Both, Map};
+    ///
+    /// let both = Both::new(2, "example");
+    /// let transformed = both.map(|left| left * 2, |right| format!("{}!", right));
+    ///
+    /// assert_eq!(transformed.left, 4);
+    /// assert_eq!(transformed.right, "example!");
+    /// ```
+    fn map<FL, FR, L2, R2>(self, fl: FL, fr: FR) -> Self::Output<L2, R2>
+    where
+        FL: FnOnce(L) -> L2,
+        FR: FnOnce(R) -> R2,
+    {
+        Both {
+            left: fl(self.left),
+            right: fr(self.right),
+        }
+    }
+}
+
+impl<L, R> Unwrap<L, R> for Both<L, R> {
+    fn left_or_else(self, _: impl FnOnce() -> L) -> L {
+        self.left
+    }
+
+    fn right_or_else(self, _: impl FnOnce() -> R) -> R {
+        self.right
     }
 }
 

--- a/src/concepts.rs
+++ b/src/concepts.rs
@@ -10,8 +10,8 @@ pub type Couple<T, U> = (T, U);
 /// A shortcut for `Couple<T, T>`.
 pub type Pair<T> = Couple<T, T>;
 
-/// The `LeftOrRight` trait provides utility methods for working with types that 
-/// can represent one of two possible variants: a "left" variant (`L`) or a 
+/// The `LeftOrRight` trait provides utility methods for working with types that
+/// can represent one of two possible variants: a "left" variant (`L`) or a
 /// "right" variant (`R`) (or possibly both).
 ///
 /// ## Provided Methods
@@ -63,5 +63,348 @@ pub trait LeftOrRight<L, R> {
     /// An `Option` containing a reference to the right value if the variant is `R`,
     /// otherwise `None`.
     fn right(&self) -> Option<&R>;
-    
+}
+
+/// The `Swap` trait extends the `LeftOrRight` trait to include the ability to swap
+/// the "left" and "right" variants of a type.
+///
+/// This can be particularly useful when working with dual-variant data structures,
+/// where you need to reverse their roles in a type-safe manner.
+///
+/// ## Associated Type
+/// - **`Output`**: The resulting type after swapping the `left` and `right` variants.
+///
+/// ## Provided Method
+/// - **`swap`**: Produces a new instance with the `left` and `right` values swapped.
+///
+/// # Examples
+/// ```rust
+/// use any_of::Both;
+/// use any_of::Swap;
+///
+/// let both = Both::new(42, "example");
+/// let swapped = both.swap();
+///
+/// assert_eq!(swapped.left, "example");
+/// assert_eq!(swapped.right, 42);
+/// ```
+pub trait Swap<L, R>: LeftOrRight<L, R> {
+    type Output: LeftOrRight<R, L>;
+
+    /// Swaps the `left` and `right` values of this `dyn LeftOrRight` instance.
+    ///
+    /// # Returns
+    /// A new `dyn LeftOrRight` instance where the `left` and `right` values are swapped.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use any_of::Both;
+    /// use any_of::concepts::Swap;
+    ///
+    /// let both = Both::new(42, "example");
+    /// let swapped = both.swap();
+    ///
+    /// assert_eq!(swapped.left, "example");
+    /// assert_eq!(swapped.right, 42);
+    /// ```
+    fn swap(self) -> Self::Output;
+}
+
+/// The `Map` trait provides utilities for transforming the `left` or `right` variants
+/// of a dual-variant type (`LeftOrRight`). This allows for ergonomic and type-safe
+/// transformations of either side of the data structure.
+///
+/// ## Provided Methods
+///
+/// - **`map_left`**: Applies a transformation to the `left` value while leaving the
+///   `right` value unchanged.
+/// - **`map_right`**: Applies a transformation to the `right` value while leaving the
+///   `left` value unchanged.
+/// - **`map`**: Applies separate transformations to the `left` and `right` values
+///   based on the variant.
+pub trait Map<L, R>: LeftOrRight<L, R> {
+    type Output<L2, R2>: LeftOrRight<L2, R2>;
+
+    /// Transforms the `L` value using a provided function.
+    ///
+    /// ## Arguments
+    ///
+    /// * `f` - A function to transform the left value.
+    ///
+    /// ## Returns
+    ///
+    /// An `LeftOrRight` where the `L` value has been transformed to an `L2`. The `R` value,
+    /// if present, remains unchanged.
+    fn map_left<FL, L2>(self, f: FL) -> Self::Output<L2, R>
+    where
+        Self: Sized,
+        FL: FnOnce(L) -> L2,
+    {
+        self.map(f, |r| r)
+    }
+
+    /// Transforms the `R` value using a provided function.
+    ///
+    /// ## Arguments
+    ///
+    /// * `f` - A function to transform the right value.
+    ///
+    /// ## Returns
+    ///
+    /// An `LeftOrRight` where the `R` value has been transformed to an `R2`. The `L` value,
+    /// if present, remains unchanged.
+    fn map_right<FR, R2>(self, f: FR) -> Self::Output<L, R2>
+    where
+        Self: Sized,
+        FR: FnOnce(R) -> R2,
+    {
+        self.map(|l| l, f)
+    }
+
+    /// Transforms the `L` or `R` value using separate functions, depending
+    /// on the variant.
+    ///
+    /// ## Arguments
+    ///
+    /// * `fl` - A function to transform the left value.
+    /// * `fr` - A function to transform the right value.
+    ///
+    /// ## Returns
+    ///
+    /// An `LeftOrRight` where the `Left` or `Right` value has been transformed
+    /// by the corresponding function.
+    fn map<FL, FR, L2, R2>(self, fl: FL, fr: FR) -> Self::Output<L2, R2>
+    where
+        FL: FnOnce(L) -> L2,
+        FR: FnOnce(R) -> R2;
+}
+
+pub trait Unwrap<L, R>: LeftOrRight<L, R> {
+    /// Returns the left value or computes a default using the provided closure.
+    ///
+    /// ## Arguments
+    ///
+    /// * `f` - A closure that generates a default value if the variant is `R`.
+    ///
+    /// ## Returns
+    ///
+    /// The left value if the variant is `L`, otherwise the default value generated
+    /// by the closure.
+    fn left_or_else(self, f: impl FnOnce() -> L) -> L;
+
+    /// Returns the right value or computes a default using the provided closure.
+    ///
+    /// ## Arguments
+    ///
+    /// * `f` - A closure that generates a default value if the variant is `L`.
+    ///
+    /// ## Returns
+    ///
+    /// The right value if the variant is `R`, otherwise the default value generated
+    /// by the closure.
+    fn right_or_else(self, f: impl FnOnce() -> R) -> R;
+
+    /// Returns the left value or a provided default.
+    ///
+    /// ## Arguments
+    ///
+    /// * `other` - The default value to use if the variant is `Right`.
+    ///
+    /// ## Returns
+    ///
+    /// The left value if the variant is `Left`, otherwise the provided default value.
+    fn left_or(self, l: L) -> L
+    where
+        Self: Sized,
+    {
+        self.left_or_else(|| l)
+    }
+
+    /// Returns the right value or a provided default.
+    ///
+    /// ## Arguments
+    ///
+    /// * `other` - The default value to use if the variant is `Left`.
+    ///
+    /// ## Returns
+    ///
+    /// The right value if the variant is `Right`, otherwise the provided default value.
+    fn right_or(self, r: R) -> R
+    where
+        Self: Sized,
+    {
+        self.right_or_else(|| r)
+    }
+
+    /// Returns the left value or a default value.
+    ///
+    /// If the variant is `Left`, this method returns the `left` value.
+    /// Otherwise, it returns the default value of the `L` type.
+    ///
+    /// ## Returns
+    ///
+    /// * `L` - The left value if it exists, or the default value of `L` otherwise.
+    ///
+    /// ## Requirements
+    ///
+    /// * The `L` type must implement the `Default` trait.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use any_of::{Either, Unwrap};
+    ///
+    /// let left = Either::Left(42);
+    /// let right: Either<i32, &str> = Either::Right("example");
+    ///
+    /// // Returns the left value as it exists.
+    /// assert_eq!(left.left_or_default(), 42);
+    ///
+    /// // Returns the default value for i32 (0) because the variant is `Right`.
+    /// assert_eq!(right.left_or_default(), 0);
+    /// ```
+    fn left_or_default(self) -> L
+    where
+        Self: Sized,
+        L: Default,
+    {
+        self.left_or(L::default())
+    }
+
+    /// Returns the right value or a default value.
+    ///
+    /// If the variant is `Right`, this method returns the `right` value.
+    /// Otherwise, it returns the default value of the `R` type.
+    ///
+    /// ## Returns
+    ///
+    /// * `R` - The right value if it exists, or the default value of `R` otherwise.
+    ///
+    /// ## Requirements
+    ///
+    /// * The `R` type must implement the `Default` trait.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use any_of::{Either, Unwrap};
+    ///
+    /// let left = Either::Left(42);
+    /// let right: Either<i32, &str> = Either::Right("example");
+    ///
+    /// // Returns the default value for &str ("") because the variant is `Left`.
+    /// assert_eq!(left.right_or_default(), "");
+    ///
+    /// // Returns the right value as it exists.
+    /// assert_eq!(right.right_or_default(), "example");
+    /// ```
+    fn right_or_default(self) -> R
+    where
+        Self: Sized,
+        R: Default,
+    {
+        self.right_or(R::default())
+    }
+
+    /// Extracts the left value, panicking with the provided message if the variant is `Right`.
+    ///
+    /// ## Arguments
+    ///
+    /// * `msg` - The panic message to display if the variant is `Right`.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the variant is `Right`.
+    ///
+    /// ## Returns
+    ///
+    /// The left value if the variant is `Left`.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use any_of::{Either, Unwrap};
+    ///
+    /// let left = Either::Left(42);
+    /// let right: Either<i32, &str> = Either::Right("example");
+    ///
+    /// // Successfully extracts the left value.
+    /// assert_eq!(left.expect_left("Expected left value"), 42);
+    ///
+    /// // Panics with the provided message.
+    /// // right.expect_left("Expected left value");
+    /// ```
+    fn expect_left(self, msg: &str) -> L
+    where
+        Self: Sized,
+    {
+        self.left_or_else(|| panic!("{}", msg))
+    }
+
+    /// Extracts the right value, panicking with the provided message if the variant is `Left`.
+    ///
+    /// ## Arguments
+    ///
+    /// * `msg` - The panic message to display if the variant is `Left`.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the variant is `Left`.
+    ///
+    /// ## Returns
+    ///
+    /// The right value if the variant is `Right`.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use any_of::{Either, Unwrap};
+    ///
+    /// let left = Either::Left(42);
+    /// let right: Either<i32, &str> = Either::Right("example");
+    ///
+    /// // Successfully extracts the right value.
+    /// assert_eq!(right.expect_right("Expected right value"), "example");
+    ///
+    /// // Panics with the provided message.
+    /// // left.expect_right("Expected right value");
+    /// ```
+    fn expect_right(self, msg: &str) -> R
+    where
+        Self: Sized,
+    {
+        self.right_or_else(|| panic!("{}", msg))
+    }
+
+    /// Extracts the left value, panicking if the variant is `Right`.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the variant is `Right`.
+    ///
+    /// ## Returns
+    ///
+    /// The left value if the variant is `Left`.
+    fn unwrap_left(self) -> L
+    where
+        Self: Sized,
+    {
+        self.expect_left("called `unwrap_left` on `LeftOrRight` value that is `Right`")
+    }
+
+    /// Extracts the right value, panicking if the variant is `Left`.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the variant is `Left`.
+    ///
+    /// ## Returns
+    ///
+    /// The right value if the variant is `Right`.
+    fn unwrap_right(self) -> R
+    where
+        Self: Sized,
+    {
+        self.expect_right("called `unwrap_right` on `LeftOrRight` value that is `Left`")
+    }
 }

--- a/src/concepts.rs
+++ b/src/concepts.rs
@@ -254,7 +254,7 @@ pub trait Unwrap<L, R>: LeftOrRight<L, R> {
     /// ```rust
     /// use any_of::{Either, Unwrap};
     ///
-    /// let left = Either::Left(42);
+    /// let left: Either<i32, &str> = Either::Left(42);
     /// let right: Either<i32, &str> = Either::Right("example");
     ///
     /// // Returns the left value as it exists.
@@ -289,7 +289,7 @@ pub trait Unwrap<L, R>: LeftOrRight<L, R> {
     /// ```rust
     /// use any_of::{Either, Unwrap};
     ///
-    /// let left = Either::Left(42);
+    /// let left: Either<i32, &str> = Either::Left(42);
     /// let right: Either<i32, &str> = Either::Right("example");
     ///
     /// // Returns the default value for &str ("") because the variant is `Left`.
@@ -325,7 +325,7 @@ pub trait Unwrap<L, R>: LeftOrRight<L, R> {
     /// ```rust
     /// use any_of::{Either, Unwrap};
     ///
-    /// let left = Either::Left(42);
+    /// let left: Either<i32, &str> = Either::Left(42);
     /// let right: Either<i32, &str> = Either::Right("example");
     ///
     /// // Successfully extracts the left value.
@@ -360,7 +360,7 @@ pub trait Unwrap<L, R>: LeftOrRight<L, R> {
     /// ```rust
     /// use any_of::{Either, Unwrap};
     ///
-    /// let left = Either::Left(42);
+    /// let left: Either<i32, &str> = Either::Left(42);
     /// let right: Either<i32, &str> = Either::Right("example");
     ///
     /// // Successfully extracts the right value.

--- a/src/either.rs
+++ b/src/either.rs
@@ -49,8 +49,7 @@
 //! Usage of the `Either` enum looks like this:
 //!
 //! ```rust
-//! use any_of::Either;
-//! use any_of::concepts::LeftOrRight;
+//! use any_of::{Either, LeftOrRight, Swap};
 //!
 //! let left_value: Either<i32, &str> = Either::new_left(10);
 //! assert!(left_value.is_left());
@@ -66,8 +65,9 @@
 //! ```
 //!
 
+use crate::concepts::{Map, Unwrap};
+use crate::{LeftOrRight, Swap};
 use core::ops::Not;
-use crate::LeftOrRight;
 
 /// The `Either` enum is a utility type that can hold a value of one of two variants: `Left(L)` or `Right(R)`.
 ///
@@ -106,147 +106,73 @@ impl<L, R> Either<L, R> {
     pub fn new_right(right: R) -> Self {
         Self::Right(right)
     }
+}
 
-    /// Returns the left value or computes a default using the provided closure.
-    ///
-    /// ## Arguments
-    ///
-    /// * `f` - A closure that generates a default value if the variant is `Right`.
-    ///
-    /// ## Returns
-    ///
-    /// The left value if the variant is `Left`, otherwise the default value generated
-    /// by the closure.
-    pub fn left_or_else(self, f: impl FnOnce() -> L) -> L {
+impl<L, R> LeftOrRight<L, R> for Either<L, R> {
+    fn is_left(&self) -> bool {
+        matches!(self, Self::Left(_))
+    }
+
+    fn is_right(&self) -> bool {
+        matches!(self, Self::Right(_))
+    }
+
+    fn any(&self) -> (Option<&L>, Option<&R>) {
+        (self.left(), self.right())
+    }
+    
+    fn left(&self) -> Option<&L> {
         match self {
-            Self::Left(l) => l,
-            Self::Right(_) => f(),
+            Self::Left(l) => Some(l),
+            Self::Right(_) => None,
         }
     }
-
-    /// Returns the right value or computes a default using the provided closure.
-    ///
-    /// ## Arguments
-    ///
-    /// * `f` - A closure that generates a default value if the variant is `Left`.
-    ///
-    /// ## Returns
-    ///
-    /// The right value if the variant is `Right`, otherwise the default value generated
-    /// by the closure.
-    pub fn right_or_else(self, f: impl FnOnce() -> R) -> R {
+    
+    fn right(&self) -> Option<&R> {
         match self {
-            Self::Left(_) => f(),
-            Self::Right(r) => r,
+            Self::Left(_) => None,
+            Self::Right(r) => Some(r),
         }
     }
+}
 
-    /// Returns the left value or a provided default.
-    ///
-    /// ## Arguments
-    ///
-    /// * `other` - The default value to use if the variant is `Right`.
-    ///
-    /// ## Returns
-    ///
-    /// The left value if the variant is `Left`, otherwise the provided default value.
-    pub fn left_or(self, other: L) -> L {
-        self.left_or_else(|| other)
-    }
-
-    /// Returns the right value or a provided default.
-    ///
-    /// ## Arguments
-    ///
-    /// * `other` - The default value to use if the variant is `Left`.
-    ///
-    /// ## Returns
-    ///
-    /// The right value if the variant is `Right`, otherwise the provided default value.
-    pub fn right_or(self, other: R) -> R {
-        self.right_or_else(|| other)
-    }
-
-    /// Extracts the left value, panicking if the variant is `Right`.
-    ///
-    /// ## Panics
-    ///
-    /// Panics if the variant is `Right`.
-    ///
-    /// ## Returns
-    ///
-    /// The left value if the variant is `Left`.
-    pub fn unwrap_left(self) -> L {
-        self.left_or_else(|| panic!("Can only unwrap left of LeftOrRight::Left"))
-    }
-
-    /// Extracts the right value, panicking if the variant is `Left`.
-    ///
-    /// ## Panics
-    ///
-    /// Panics if the variant is `Left`.
-    ///
-    /// ## Returns
-    ///
-    /// The right value if the variant is `Right`.
-    pub fn unwrap_right(self) -> R {
-        self.right_or_else(|| panic!("Can only unwrap right of LeftOrRight::Right"))
-    }
-
+impl<L, R> Swap<L, R> for Either<L, R> {
+    type Output = Either<R, L>;
     /// Swaps the variants of the `Either`, turning a `Left` into a `Right` and vice versa.
     ///
     /// ## Returns
     ///
     /// An `Either` with the variants swapped. The `Left` value becomes `Right`,
     /// and the `Right` value becomes `Left`.
-    pub fn swap(self) -> Either<R, L> {
+    fn swap(self) -> Self::Output {
         match self {
             Self::Left(l) => Either::<R, L>::Right(l),
             Self::Right(r) => Either::<R, L>::Left(r),
         }
     }
+}
 
-    /// Transforms the `Left` value using a provided function.
-    ///
-    /// ## Arguments
-    ///
-    /// * `f` - A function to transform the left value.
-    ///
-    /// ## Returns
-    ///
-    /// An `Either` where the `Left` value has been transformed. The `Right` value,
-    /// if present, remains unchanged.
-    pub fn map_left<FL: FnOnce(L) -> L2, L2>(self, f: FL) -> Either<L2, R> {
-        self.map(f, |r| r)
-    }
+impl<L, R> Map<L, R> for Either<L, R> {
+    type Output<L2, R2> = Either<L2, R2>;
 
-    /// Transforms the `Right` value using a provided function.
-    ///
-    /// ## Arguments
-    ///
-    /// * `f` - A function to transform the right value.
-    ///
-    /// ## Returns
-    ///
-    /// An `Either` where the `Right` value has been transformed. The `Left` value,
-    /// if present, remains unchanged.
-    pub fn map_right<FR: FnOnce(R) -> R2, R2>(self, f: FR) -> Either<L, R2> {
-        self.map(|l| l, f)
-    }
-
-    /// Transforms the `Left` or `Right` value using separate functions, depending
+    /// Transforms the `L` or `R` value using separate functions, depending
     /// on the variant.
+    /// 
+    /// # Type Parameters
+    /// - `L2`: The resulting type of the transformed `left` value.
+    /// - `R2`: The resulting type of the transformed `right` value.
+    /// - `FL`: The type of the function used to transform the `left` value.
+    /// - `FR`: The type of the function used to transform the `right` value.
     ///
-    /// ## Arguments
-    ///
-    /// * `fl` - A function to transform the left value.
-    /// * `fr` - A function to transform the right value.
+    /// # Arguments
+    /// - `fl`: A function that takes the `left` value and transforms it into a value of type `L2`.
+    /// - `fr`: A function that takes the `right` value and transforms it into a value of type `R2`.
     ///
     /// ## Returns
     ///
     /// An `Either` where the `Left` or `Right` value has been transformed
     /// by the corresponding function.
-    pub fn map<FL, FR, L2, R2>(self, fl: FL, fr: FR) -> Either<L2, R2>
+    fn map<FL, FR, L2, R2>(self, fl: FL, fr: FR) -> Self::Output<L2, R2>
     where
         FL: FnOnce(L) -> L2,
         FR: FnOnce(R) -> R2,
@@ -258,39 +184,20 @@ impl<L, R> Either<L, R> {
     }
 }
 
-impl<L, R> LeftOrRight<L, R> for Either<L, R> {
-
-    /// See [crate::LeftOrRight::is_left].
-    fn is_left(&self) -> bool {
-        matches!(self, Self::Left(_))
-    }
-
-    /// See [crate::LeftOrRight::is_right].
-    fn is_right(&self) -> bool {
-        matches!(self, Self::Right(_))
-    }
-
-    /// See [crate::LeftOrRight::any].
-    fn any(&self) -> (Option<&L>, Option<&R>) {
-        (self.left(), self.right())
-    }
-
-    /// See [crate::LeftOrRight::left].
-    fn left(&self) -> Option<&L> {
+impl<L, R> Unwrap<L, R> for Either<L, R> {
+    fn left_or_else(self, f: impl FnOnce() -> L) -> L {
         match self {
-            Self::Left(l) => Some(l),
-            Self::Right(_) => None,
+            Self::Left(l) => l,
+            Self::Right(_) => f(),
         }
     }
 
-    /// See [crate::LeftOrRight::right].
-    fn right(&self) -> Option<&R> {
+    fn right_or_else(self, f: impl FnOnce() -> R) -> R {
         match self {
-            Self::Left(_) => None,
-            Self::Right(r) => Some(r),
+            Self::Left(_) => f(),
+            Self::Right(r) => r,
         }
     }
-
 }
 
 impl<L, R> Not for Either<L, R> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,4 @@
-use crate::AnyOf;
-use crate::LeftOrRight;
+use crate::{AnyOf, LeftOrRight, Map, Unwrap};
 
 mod utils {
     use core::ops::Add;
@@ -23,7 +22,6 @@ fn test_any_of_right() {
     assert_eq!(mul2.left(), None);
     assert_eq!(mul2.unwrap_right(), 2.2);
 }
-
 
 #[test]
 fn test_any_of_neither() {


### PR DESCRIPTION
- Added `Swap` trait and implementations for `Both`, `Either` and `AnyOf`.
- Added `Map` trait and implementations for `Both`, `Either`, and `AnyOf`.
- Added `Unwrap` trait and implementations for `Both`, `Either`, and `AnyOf`.
- Updated documentation and examples for the newly added traits.
- Adjusted imports across: `src`, `tests.rs`, and `lib.rs`.
- Replaced the single build status badge with a table format.
- Added build status for both `dev` and `master` branches.
- Specify types in `Either` example definitions.