### PR TITLE
Merge on Master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ## `2.1` 
 
+### `2.1.1`
+
+- Added default type parameter `R = L` for `BothOf` and `EitherOf`.
+- Updated README with adjusted type examples and operator clarifications.
+- Improved code samples and operator descriptions in `src/lib.rs`.
+- Adjusted test example output to align with changes.
+- Fixed and cleaned up the shr method's example.
+- Modified doc comments for consistency.
+
 ### `2.1.0`
 
 `>>` operator and `Not` as a super-trait.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "any_of"
-version = "2.1.0"
+version = "2.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "any_of"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 description = "A general optional sum of product type which can be Neither, Left, Right or Both."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -26,11 +26,16 @@ manner.
         - `Both`: Both values are present.
     - It combines variants in the following way:
       ```
-      AnyOf<L, R> = Neither | EitherOf<L, R> | BothOf<L, R>
+      AnyOf<L, R> = Neither
+                  | Either(EitherOf<L, R>)
+                  | Both(BothOf<L, R>)
       ```
     - Its cases are:
       ```
-      AnyOf(L, R) = Neither | Left(L) | Right(R) | BothOf{left: L, right: R}
+      AnyOf(l: L, r: R) = Neither 
+                        | Either(Left(l))
+                        | Either(Right(r)) 
+                        | Both(BothOf{left = l, right = r})
       ```
     - This type can also be viewed as a product of two optional types:
       ```
@@ -91,10 +96,10 @@ manner.
 
 - Flexible combinations:
     - Operators :
-        - `+` to combine `AnyOf` values, or,
-        - `-` to filter `AnyOf` values, or,
-        - `!` to swap  `AnyOf`, `EitherOf` and `BothOf` values,
-        - `>>` to map  `AnyOf`, `EitherOf` and `BothOf` values,
+        - `+` to **combine** `AnyOf` values, or,
+        - `-` to **filter** `AnyOf` values, or,
+        - `!` to **swap**  `AnyOf`, `EitherOf` and `BothOf` values,
+        - `>>` to **map**  `AnyOf`, `EitherOf` and `BothOf` values,
     - Default value handling and state manipulation methods.
 
 ![Type diagram PNG](doc/any_of-type-diagram.png)

--- a/src/both.rs
+++ b/src/both.rs
@@ -69,7 +69,7 @@ use core::ops::{Not, Shr};
 ///
 /// For more examples, see the documentation of the individual methods below.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
-pub struct BothOf<L, R> {
+pub struct BothOf<L, R = L> {
     pub left: L,
     pub right: R,
 }

--- a/src/either.rs
+++ b/src/either.rs
@@ -77,7 +77,7 @@ use core::ops::{Not, Shr};
 /// on values of two possible types. Unlike `Result`, it does not imply any specific meaning
 /// to the variants.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
-pub enum EitherOf<L, R> {
+pub enum EitherOf<L, R = L> {
     Left(L),
     Right(R),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,18 +447,18 @@ impl<L, R> AnyOf<L, R> {
     /// ## All cases
     ///
     /// * Neither cases :
-    ///     * Neither & Neither = Neither
-    ///     * Neither & **other** = other
-    ///     * **self** & Neither = self
+    ///     * Neither + Neither = Neither
+    ///     * Neither + **other** = other
+    ///     * **self** + Neither = self
     /// * Trivial cases :
-    ///     * **Left(x)** & Left(y) = Left(x)
-    ///     * Right(x) & **Right(y)** = Right(y)
-    ///     * **Both(x, y)** & other = Both(x, y)
+    ///     * **Left(x)** + Left(y) = Left(x)
+    ///     * Right(x) + **Right(y)** = Right(y)
+    ///     * **Both(x, y)** + other = Both(x, y)
     /// * Combined cases :
-    ///     * Left(x) & Right(y) = Both(x, y)
-    ///     * Right(x) & Left(y) = Both(y, x)
-    ///     * Left(x) & Both(_, y) = Both(x, y)
-    ///     * Right(x) & Both(y, _) = Both(y, x)
+    ///     * Left(x) + Right(y) = Both(x, y)
+    ///     * Right(x) + Left(y) = Both(y, x)
+    ///     * Left(x) + Both(_, y) = Both(x, y)
+    ///     * Right(x) + Both(y, _) = Both(y, x)
     pub fn combine(self, other: Self) -> Self {
         match self {
             Neither => other,
@@ -491,17 +491,17 @@ impl<L, R> AnyOf<L, R> {
     /// ## All cases
     ///
     /// - **Neither cases**:
-    ///     * `Neither | other = Neither`
-    ///     * `Left(x) | Left(y) = Neither`
-    ///     * `Right(x) | Right(y) = Neither`
-    ///     * `other | Both(x, y) = Neither`
+    ///     * `Neither - other = Neither`
+    ///     * `Left(x) - Left(y) = Neither`
+    ///     * `Right(x) - Right(y) = Neither`
+    ///     * `other - Both(x, y) = Neither`
     /// - **Trivial case**:
-    ///     * `other | Neither = other`
+    ///     * `other - Neither = other`
     /// - **Filtered cases**:
-    ///     * `Left(x) | Right(y) = Left(x)`
-    ///     * `Right(x) | Left(y) = Right(x)`
-    ///     * `Both(x, y) | Right(y) = Left(x)`
-    ///     * `Both(x, y) | Left(y) = Right(y)`
+    ///     * `Left(x) - Right(y) = Left(x)`
+    ///     * `Right(x) - Left(y) = Right(x)`
+    ///     * `Both(x, y) - Right(z) = Left(x)`
+    ///     * `Both(x, y) - Left(z) = Right(y)`
     ///
     /// # Examples
     ///
@@ -658,14 +658,19 @@ where
     /// # Examples
     ///
     /// ```
-    /// use any_of::{AnyOf, BothOf    };
+    /// use any_of::{AnyOf, Left, Unwrap};
     ///
-    /// let both = AnyOf::Both(BothOf { left: 5, right: 10 });
     /// let left_fn = |x: i32| x * 2;
-    /// let right_fn = |y: i32| y + 3;
+    /// let right_fn  = |y: i32| y + 3;
+    /// let both_fn = (left_fn, right_fn).into();
     ///
-    /// let result = both >> (left_fn, right_fn).into();
-    /// assert_eq!(result, AnyOf::Both(BothOf { left: 10, right: 13 }));
+    /// let both:AnyOf<i32, i32> = (5, 10).into();
+    /// let result = both >> both_fn;
+    /// assert_eq!(result, (10, 13).into());
+    ///
+    /// let left = AnyOf::Either(Left(25));
+    /// let left_result = left >> both_fn;
+    /// assert_eq!(left_result.unwrap_left(), 50);
     /// ```
     fn shr(self, rhs: BothOf<FL, FR>) -> Self::Output {
         match self {


### PR DESCRIPTION
BothOf and EitherOf now support a default type for the right parameter, reducing the need for explicit type annotations in common cases. Updated related documentation and added clarifying examples to improve understanding of new behavior.

Changes:
- Added default type parameter `R = L` for `BothOf` and `EitherOf`.
- Updated README with adjusted type examples and operator clarifications.
- Improved code samples and operator descriptions in `src/lib.rs`.
- Adjusted test example output to align with changes.
- Fixed and cleaned up the shr method's example.
- Modified doc comments for consistency with new behavior.